### PR TITLE
Add multibuild script and README for use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vagrant
+*/venv
+*/project
+*.pyc

--- a/multibuild/README.md
+++ b/multibuild/README.md
@@ -1,0 +1,36 @@
+# Multibuild script for Maven Projects
+
+This setup is intended to run multiple builds against a specific Indy instance.
+
+## User Input
+
+The user must provide the following:
+
+* A project to build, normally in the `./project` directory (or you can specify a different directory)
+* An Indy URL, with httprox enabled and everything setup to work with the `public` group
+
+## Using with the Vagrant VMs
+
+To use this with the Vagrant configuration contained in this project, run the VMs. You can use the instructions in
+the root README to fine-tune these VMs for your test.
+
+Use `vagrant ssh-config client` in the root directory of this repository to get the host IP address for the Indy
+instance. Once you have this, you can use `http://<IP>:8080` as the Indy URL for input into the multibuild script.
+
+## Example
+
+Starting from the project root directory (directory above this one):
+
+```
+    $ vagrant up
+    $ export INDY=$(vagrant ssh-config client | grep HostName | awk '{print $2}')
+
+    [CONNECT TO INDY UI AT http://${INDY}:8080 and configure it appropriately]
+
+    $ cd multibuild
+    $ git clone https://github.com/Commonjava/indy project
+    $ ./multibuild.py -b 4 -t 2 -P 8081 http://${INDY}L:8080
+
+    [BUILDS RUN]
+```
+

--- a/multibuild/mb/__init__.py
+++ b/multibuild/mb/__init__.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from datetime import datetime as dt
+
+def run_cmd(cmd, fail=True):
+    """Run the specified command. If fail == True, and a non-zero exit value 
+       is returned from the process, then exit the program
+    """
+    print cmd
+    ret = os.system(cmd)
+    if ret != 0:
+        print 'Error running command'
+        if fail:
+            sys.exit(1)
+
+
+def setup_builddir(projectdir, idx):
+    if os.path.isdir('builds') is False:
+        os.makedirs('builds')
+
+    builddir="builds/project-%s-%s" % ((dt.now()-dt.utcfromtimestamp(0)).total_seconds(), idx)
+
+    run_cmd("git clone file://%s %s" % (projectdir, builddir))
+    
+    return os.path.join(os.getcwd(), builddir)

--- a/multibuild/mb/builder.py
+++ b/multibuild/mb/builder.py
@@ -1,0 +1,156 @@
+import os
+import requests
+import json
+from threading import Thread
+from urlparse import urlparse
+import mb
+
+SETTINGS = """
+<?xml version="1.0"?>
+<settings>
+  <localRepository>%(dir)s/local-repo</localRepository>
+  <mirrors>
+    <mirror>
+      <id>indy</id>
+      <mirrorOf>*</mirrorOf>
+      <url>%(url)s/api/folo/track/%(id)s/group/%(id)s</url>
+    </mirror>
+  </mirrors>
+  <proxies>
+    <proxy>
+      <id>indy-httprox</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>%(host)s</host>
+      <port>%(proxy_port)s</port>
+      <username>%(id)s+tracking</username>
+      <password>foo</password>
+      <nonProxyHosts>%(host)s</nonProxyHosts>
+    </proxy>
+  </proxies>
+  <profiles>
+    <profile>
+      <id>resolve-settings</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>%(url)s/api/folo/track/%(id)s/group/%(id)s</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>%(url)s/api/folo/track/%(id)s/group/%(id)s</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+    
+    <profile>
+      <id>deploy-settings</id>
+      <properties>
+        <altDeploymentRepository>%(id)s::default::%(url)s/api/folo/track/%(id)s/hosted/%(id)s</altDeploymentRepository>
+      </properties>
+    </profile>
+    
+  </profiles>
+  <activeProfiles>
+    <activeProfile>resolve-settings</activeProfile>
+    
+    <activeProfile>deploy-settings</activeProfile>
+    
+  </activeProfiles>
+</settings>
+"""
+
+POST_HEADERS = {'content-type': 'application/json'}
+
+class Builder(Thread):
+    def __init__(self, queue):
+        Thread.__init__(self)
+        self.queue = queue
+
+    def run(self):
+        while True:
+            try:
+                (builddir, indy_url, proxy_port) = self.queue.get()
+
+                parsed = urlparse(indy_url)
+                params = {'dir': builddir, 'url':indy_url, 'id': os.path.basename(builddir), 'host': parsed.hostname, 'port': parsed.port, 'proxy_port': proxy_port}
+
+                self.setup(builddir, params);
+                self.build(builddir)
+                self.seal_folo_report(params)
+                self.pull_folo_report(params)
+
+                self.queue.task_done()
+            except KeyboardInterrupt:
+                print "Keyboard interrupt in process: ", process_number
+                break
+
+    def pull_folo_report(self, params):
+        """Pull the Folo tracking report associated with the current build"""
+
+        resp = requests.get("%(url)s/api/folo/admin/%(id)s/record" % params)
+        resp.raise_for_status()
+
+    def seal_folo_report(self, params):
+        """Seal the Folo tracking report after the build completes"""
+
+        resp = requests.post("%(url)s/api/folo/admin/%(id)s/record" % params, data={})
+        resp.raise_for_status()
+
+    def build(self, builddir):
+        mb.run_cmd("mvn -f %(d)s/pom.xml -s %(d)s/settings.xml clean deploy" % {'d': builddir})
+
+    def setup(self, builddir, params):
+        """Create the hosted repo and group, then pull the Indy-generated Maven
+           settings.xml file tuned to that group."""
+
+        hosted = {
+            'type': 'hosted', 
+            'key': "hosted:%(id)s" % params, 
+            'disabled': False, 
+            'doctype': 'hosted', 
+            'name': params['id'], 
+            'allow_releases': True
+        }
+
+        print "POSTing: %s" % json.dumps(hosted, indent=2)
+
+        resp = requests.post("%(url)s/api/admin/hosted" % params, json=hosted, headers=POST_HEADERS)
+        resp.raise_for_status()
+
+        group = {
+            'type': 'group', 
+            'key': "group:%(id)s" % params, 
+            'disabled': False, 
+            'doctype': 'group', 
+            'name': params['id'], 
+            'constituents': [
+                "hosted:%(id)s" % params, 
+                'group:public'
+            ]
+        }
+
+        print "POSTing: %s" % json.dumps(group, indent=2)
+
+        resp = requests.post("%(url)s/api/admin/group" % params, json=group, headers=POST_HEADERS)
+        resp.raise_for_status()
+
+        resp = requests.get("%(url)s/mavdav/settings/group/settings-%(id)s.xml" % params)
+        resp.raise_for_status()
+
+        with open("%s/settings.xml" % builddir, 'w') as f:
+            f.write(SETTINGS % params)

--- a/multibuild/multibuild.py
+++ b/multibuild/multibuild.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import os
+from Queue import Queue
+import argparse
+import time
+
+import mb
+import mb.builder
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('indy_url', help='Indy base url (eg. http://localhost:8080)')
+parser.add_argument('-p', '--project', default='project', help='Directory to clone to serve as build root')
+parser.add_argument('-b', '--total-builds', type=int, default=6, help='Number of total builds to run')
+parser.add_argument('-t', '--threads', type=int, default=2, help='Number of builders')
+parser.add_argument('-P', '--proxy-port', type=int, default=8081, help='Port for generic HTTP proxy')
+
+args = parser.parse_args()
+
+projectdir = os.path.join(os.getcwd(), args.project)
+
+queue = Queue()
+
+try:
+    for t in range(args.threads):
+        thread = mb.builder.Builder(queue)
+        thread.daemon = True
+        thread.start()
+
+    for x in range(args.total_builds):
+        builddir = mb.setup_builddir(projectdir, x)
+        queue.put((builddir, args.indy_url, args.proxy_port))
+
+    while queue.empty() is False:
+        time.sleep(100)
+except (KeyboardInterrupt, SystemExit):
+    print "Quitting."
+


### PR DESCRIPTION
This is the other half of the manual load testing setup for Indy, with
the Indy / NFS Vagrant VMs being the first half.

This script will run the same build multiple total times with a given
number of builder processes, using unique Folo tracking IDs for each.