### PR TITLE
Improve Indy restart functions with NFS mounting at a higher location…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 indy-overlay
 */builds
+indy.tar.gz*

--- a/client/start-indy.sh
+++ b/client/start-indy.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+# Show everything this script does in the journal.
 set -x
 
-for p in $(rpcinfo -p | awk '{print $4}' | grep -v port | sort -n | uniq)
-do
+# Ensure applicable ports are open on the firewall, just in case
+for p in $(rpcinfo -p | awk '{print $4}' | grep -v port | sort -n | uniq); do
     echo "Adding port $p tcp/udp to iptables"
     iptables -A INPUT -p tcp --dport $p -j ACCEPT
     iptables -A INPUT -p udp --dport $p -j ACCEPT
@@ -11,63 +12,74 @@ done
 
 INDY_URL=http://repo.maven.apache.org/maven2/org/commonjava/indy/launch/indy-launcher-savant/1.1.5/indy-launcher-savant-1.1.5-launcher.tar.gz
 MOUNT_OPTS='rw,relatime,vers=4.0,rsize=65536,wsize=65536,namlen=255,hard,proto=tcp,timeo=600,retrans=2,local_lock=none'
+USE_NFS='N'
 
-if [ -f /vagrant/client/indy-info ]
-then
-    source /vagrant/client/indy-info
-fi
+# if [ -f /vagrant/client/indy-info ]; then
+#     source /vagrant/client/indy-info
+# fi
 
-if [ "x" != "x$(df | grep 192.168.50.2)" ]; then
-    umount /opt/indy/var/lib/indy/storage
+if [ "x${USE_NFS}" = 'xY' ]; then
+    # Unmount the NFS volume to refresh it, just in case something has gone stale
+    if [ "x" != "x$(df | grep 192.168.50.2)" ]; then
+        umount /opt/indy/var/lib/indy
+    fi
 fi
 
 rm -rf /opt/indy
 
 name=$(basename $INDY_URL)
 
-if [ -d /vagrant/indy ]
-then
+if [ -d /vagrant/indy ]; then
+    # Use an Indy directory uploaded from the host environment
     cp -rf /vagrant/indy /opt/indy
-elif [ -f /vagrant/indy.tar.gz ]
-then
+elif [ -f /vagrant/indy.tar.gz ]; then
+    # unpack a tarball uploaded from the host environment
     tar -zxf /vagrant/indy.tar.gz -C /opt
 else
-    if [ ! -f /tmp/$name ]
-    then
+    # possibly retrieve, and then unpack, the release from the URL
+    if [ ! -f /tmp/$name ]; then
         echo "Retrieving Indy from: $INDY_URL to: /tmp/$name"
         wget --quiet -O /tmp/$name $INDY_URL
     fi
     tar -zxf /tmp/$name -C /opt
 fi
 
+if [ "x${USE_NFS}" = 'xY' ]; then
+    # Be double-sure this directory exists before we try to mount to it
+    if [ ! -d /opt/indy/var/lib/indy ]; then
+        mkdir -p /opt/indy/var/lib/indy
+    fi
+
+    # Save the UI, to overwrite into NFS mount
+    rm -rf /opt/ui
+    mv /opt/indy/var/lib/indy/ui/ /opt/ui/
+
+    # Re-mount NFS
+    if [ "x" == "x$(df | grep 192.168.50.2)" ]; then
+        mount -t nfs -o "$MOUNT_OPTS" 192.168.50.2:/exports/test /opt/indy/var/lib/indy
+    fi
+
+    # Overwrite UI in NFS mount
+    rm -rf /opt/indy/var/lib/indy/ui
+    mv /opt/ui/ /opt/indy/var/lib/indy/ui/
+fi
+
+# Copy in the overlay files
 if [ -d /vagrant/indy-overlay ]; then
     cp -rf /vagrant/indy-overlay/* /opt/indy
 fi
 
-if [ ! -d /opt/indy/var/lib/indy/storage ]
-then
-    mkdir -p /opt/indy/var/lib/indy/storage
-fi
-
 INDY_LOGS=/opt/indy/var/log/indy
 
-if [ ! -e $INDY_LOGS -o ! -L $INDY_LOGS ]; then
-    rm -rf $INDY_LOGS
+rm -rf $INDY_LOGS
 
-    if [ ! -d /var/log/indy ]; then
-        mkdir /var/log/indy
-        chown -R vagrant /var/log/indy
-    fi
-
-    if [ ! -d /opt/indy/var/log ]; then
-        mkdir -p /opt/indy/var/log
-    fi
-
-    ln -s /var/log/indy $INDY_LOGS
+# Try to divert Indy logs to a place that won't be removed on restart
+if [ ! -d /var/log/indy ]; then
+    mkdir /var/log/indy
+    chown -R vagrant /var/log/indy
 fi
 
-if [ "x" == "x$(df | grep 192.168.50.2)" ]; then
-    mount -t nfs -o "$MOUNT_OPTS" 192.168.50.2:/exports/test /opt/indy/var/lib/indy/storage
-fi
+ln -s /var/log/indy $INDY_LOGS
 
+# Now, start Indy
 exec /opt/indy/bin/indy.sh

--- a/multibuild/mb/reporter.py
+++ b/multibuild/mb/reporter.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+import requests
+import shutil
+import hashlib
+from threading import Thread
+
+EXTS = ['.jar', '.pom', '.tar.gz', '.zip']
+
+class Reporter(Thread):
+    def __init__(self, report_queue):
+        Thread.__init__(self)
+        self.queue = report_queue
+
+    def run(self):
+        while True:
+            try:
+                (builddir, report) = self.queue.get()
+
+                report_name = os.path.basename(builddir)
+
+                input_name = os.path.join(builddir, "%s-report.json" % report_name)
+                with open(input_name, 'w') as f:
+                    f.write(json.dumps(report, indent=2))
+
+                downloads = report.get('downloads') or []
+                uploads = report.get('uploads') or []
+
+                tmp = 'content-temp'
+                if os.path.isdir(tmp):
+                    shutil.rmtree(tmp)
+
+                os.makedirs(tmp)
+
+                print "Got %d downloads and %d uploads" % (len(downloads), len(uploads))
+
+                entries = []
+                if uploads is not None:
+                    for e in uploads:
+                        entries.append({'dataset': 'upload', 'entry': e})
+
+                if downloads is not None:
+                    for e in downloads:
+                        entries.append({'dataset': 'download', 'entry': e})
+
+                result = {'results': []}
+                self._process_partition(entries, result['results'])
+
+                output_name = os.path.join(builddir, "%s-verify.json" % report_name)
+                with open(output_name, 'w') as f:
+                    f.write(json.dumps(result, indent=2))
+
+                print "Wrote: %s (%d results)" % (output_name, len(result['results']))
+            except KeyboardInterrupt:
+                print "Keyboard interrupt in process: ", process_number
+                break
+            finally:
+                self.queue.task_done()
+
+    def _process_partition(self, partition, results):
+        for p in partition:
+            entry = p['entry']
+            path = entry['path'][1:]
+            proceed = False
+            for e in EXTS:
+                if path.endswith(e):
+                    proceed = True
+                    break
+
+            if proceed:
+                url = entry['localUrl']
+                print "Checking: %s" % url
+
+                r = requests.get(url, stream=True)
+                if r.status_code != 200:
+                    raise Exception("Failed to download: %s" % url)
+
+                header_size=int(r.headers['content-length'])
+
+                dest = os.path.join(tmp, path)
+                destdir = os.path.dirname(dest)
+                if not os.path.isdir(destdir):
+                    os.makedirs(destdir)
+
+                with open(dest, 'wb') as f:
+                    #r.raw.decode_content = True
+                    shutil.copyfileobj(r.raw, f)
+
+                entry_data = {'path': path, 'local_url': url, 'type':p['dataset']}
+
+                dest_sz = os.path.getsize(dest)
+                if entry['size'] != dest_sz or entry['size'] != header_size or dest_sz != header_size:
+                    entry_data['size'] = {'success': False, 'record': entry['size'], 'header': header_size, 'calculated': dest_sz}
+                else:
+                    entry_data['size'] = {'success': True}
+
+                self._compare_checksum('md5', url, dest, entry, entry_data)
+                self._compare_checksum('sha1', url, dest, entry, entry_data)
+                # compare_checksum('sha256', url, dest, entry, entry_data)
+
+                append=False
+                for k in ['size', 'md5', 'sha1']:
+                    if entry[k]['success'] is False:
+                        append = True
+                        break
+
+                if append is True:
+                    results.append(entry_data)
+
+        return results
+
+    def _compare_checksum(self, checksum_type, url, dest, entry, entry_data):
+        check_url = url + '.' + checksum_type
+        print "Retrieving checksum: %s" % check_url
+        
+        r = requests.get(check_url)
+        if r.status_code == 200:
+            check_file = r.text
+        else:
+            check_file = None
+
+        check = hashlib.new(checksum_type, open(dest, 'rb').read()).hexdigest()
+        if entry[checksum_type] != check: # or entry[checksum_type] != check_file or check != check_file:
+            entry_data[checksum_type] = {'success': False, 'record': entry[checksum_type], 'file': check_file, 'calculated': check}
+        else:
+            entry_data[checksum_type] = {'success': True}
+

--- a/multibuild/multibuild.py
+++ b/multibuild/multibuild.py
@@ -7,12 +7,15 @@ import time
 
 import mb
 import mb.builder
+import mb.reporter
+
+DELAY=0
 
 parser = argparse.ArgumentParser()
 
 parser.add_argument('indy_url', help='Indy base url (eg. http://localhost:8080)')
 parser.add_argument('-p', '--project', default='project', help='Directory to clone to serve as build root')
-parser.add_argument('-b', '--total-builds', type=int, default=6, help='Number of total builds to run')
+parser.add_argument('-b', '--total-builds', type=int, default=4, help='Number of total builds to run')
 parser.add_argument('-t', '--threads', type=int, default=2, help='Number of builders')
 parser.add_argument('-P', '--proxy-port', type=int, default=8081, help='Port for generic HTTP proxy')
 
@@ -20,20 +23,27 @@ args = parser.parse_args()
 
 projectdir = os.path.join(os.getcwd(), args.project)
 
-queue = Queue()
+build_queue = Queue()
+report_queue = Queue()
 
 try:
     for t in range(args.threads):
-        thread = mb.builder.Builder(queue)
+        thread = mb.builder.Builder(build_queue, report_queue)
         thread.daemon = True
         thread.start()
 
     for x in range(args.total_builds):
         builddir = mb.setup_builddir(projectdir, x)
-        queue.put((builddir, args.indy_url, args.proxy_port))
+        build_queue.put((builddir, args.indy_url, args.proxy_port, (x % args.threads)*DELAY))
 
-    while queue.empty() is False:
-        time.sleep(100)
+    build_queue.join()
+
+    for t in range(args.threads):
+        thread = mb.reporter.Reporter(report_queue)
+        thread.daemon = True
+        thread.start()
+
+    report_queue.join()
 except (KeyboardInterrupt, SystemExit):
     print "Quitting."
 

--- a/nfs/tc.sh
+++ b/nfs/tc.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-tcset --device eth1 --delay 50 --loss 10 --overwrite
+systemctl status nfs || systemctl restart nfs
+
+#tcset --device eth1 --delay 50 --loss 10 --overwrite
 tcshow --device eth1
 
-tcpdump -w /tmp/tcdump.log port nfs
+nohup tcpdump -w /tmp/tcdump.log port nfs &
 
-systemctl status nfs || systemctl restart nfs

--- a/provision-client.sh
+++ b/provision-client.sh
@@ -5,6 +5,8 @@ yum clean all
 cat > /etc/systemd/system/indy.service << '__EOF__'
 [Unit]
 Description=Indy
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 Restart=always

--- a/provision-nfs.sh
+++ b/provision-nfs.sh
@@ -19,7 +19,9 @@ done
 
 cat > /etc/systemd/system/tcconfig.service << '__EOF__'
 [Unit]
-Description=TC Configuration
+Description=Network Configuration
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 Restart=always


### PR DESCRIPTION
…. Add report checking to multibuild.

Previously we were just mounting NFS for artifact storage. This meant that tracking reports wouldn't
be carried over a vagrant VM restart on the client (Indy) VM. However, changing to mount NFS one
directory higher meant that the UI files would have to be copied in from the new Indy tarball
to the NFS volume in order to preserve the Indy web UI.

In addition, I needed the ability to turn off the NFS mount altogether in an Indy deployment
to test with a local-to-the-VM disk. I added a USE_NFS variable to the start-indy.sh script
for this purpose.

To make the VMs more stable on startup, I added network targets to the systemd scripts,
to make the NFS and Indy startups wait until a valid network connection exists.

Finally, I added a reporter function to multibuild.py, which is an adaptation
of the check-report.py script I wrote earlier. It performs the same basic
steps, and writes the file out to the builds/<tracking-id> directory, to
a JSON file.