### PR TITLE
Fix up partioning between builder and reporter. Provide report-verification script.

### DIFF
--- a/client/start-indy.sh
+++ b/client/start-indy.sh
@@ -12,7 +12,7 @@ done
 
 INDY_URL=http://repo.maven.apache.org/maven2/org/commonjava/indy/launch/indy-launcher-savant/1.1.5/indy-launcher-savant-1.1.5-launcher.tar.gz
 MOUNT_OPTS='rw,relatime,vers=4.0,rsize=65536,wsize=65536,namlen=255,hard,proto=tcp,timeo=600,retrans=2,local_lock=none'
-USE_NFS='N'
+USE_NFS='Y'
 
 # if [ -f /vagrant/client/indy-info ]; then
 #     source /vagrant/client/indy-info

--- a/multibuild/mb/builder.py
+++ b/multibuild/mb/builder.py
@@ -99,21 +99,13 @@ class Builder(Thread):
 
                 self.build(builddir)
                 self.seal_folo_report(params)
-                self.reports.put((builddir,self.pull_folo_report(params)))
+                self.reports.put((builddir,params['url'], params['id']))
 
             except KeyboardInterrupt:
                 print "Keyboard interrupt in process: ", process_number
                 break
             finally:
                 self.queue.task_done()
-
-    def pull_folo_report(self, params):
-        """Pull the Folo tracking report associated with the current build"""
-
-        resp = requests.get("%(url)s/api/folo/admin/%(id)s/record" % params)
-        resp.raise_for_status()
-
-        return resp.json()
 
     def seal_folo_report(self, params):
         """Seal the Folo tracking report after the build completes"""

--- a/multibuild/mb/reporter.py
+++ b/multibuild/mb/reporter.py
@@ -10,6 +10,154 @@ from threading import Thread
 
 EXTS = ['.jar', '.pom', '.tar.gz', '.zip']
 
+def get_sealed_reports(url):
+    resp = requests.get("%s/api/folo/admin/report/ids/sealed" % url)
+    if resp.status_code != 200:
+        print resp.text
+
+    resp.raise_for_status()
+
+    report_list = resp.json()
+
+    return [str(tid) for tid in report_list.get('sealed') or []]
+
+def verify_report(builddir, url, tracking_id):
+    print "Checking tracking report: %s" % tracking_id
+
+    print "Retrieving tracking report: %s" % tracking_id
+
+    report = _pull_folo_report({'url': url, 'id': tracking_id})
+
+    report_name = os.path.basename(builddir)
+
+    print "Writing copy of tracking report: %s" % tracking_id
+
+    input_name = os.path.join(builddir, "%s-report.json" % report_name)
+    with open(input_name, 'w') as f:
+        f.write(json.dumps(report, indent=2))
+
+    downloads = report.get('downloads') or []
+    uploads = report.get('uploads') or []
+
+    tmp = os.path.join(builddir, 'content-temp')
+    if os.path.isdir(tmp):
+        shutil.rmtree(tmp)
+
+    os.makedirs(tmp)
+
+    print "Got %d downloads and %d uploads" % (len(downloads), len(uploads))
+
+    entries = []
+    for e in uploads:
+        entries.append({'dataset': 'upload', 'entry': e})
+
+    for e in downloads:
+        entries.append({'dataset': 'download', 'entry': e})
+
+    print "Processing %s entries for tracking report: %s" % (len(entries), tracking_id)
+
+    result = {'results': []}
+    _process_partition(url, entries, result['results'], tmp)
+
+    print "Writing %s failed entries for tracking report: %s" % (len(result['results']), tracking_id)
+
+    output_name = os.path.join(builddir, "%s-verify.json" % report_name)
+    with open(output_name, 'w') as f:
+        f.write(json.dumps(result, indent=2))
+
+    print "Tracking report analysis completed for: %s" % tracking_id
+
+def _pull_folo_report(params):
+    """Pull the Folo tracking report associated with the current build"""
+
+    resp = requests.get("%(url)s/api/folo/admin/%(id)s/record" % params)
+    resp.raise_for_status()
+
+    return resp.json()
+
+def _process_partition(base_url, partition, results, tmp):
+    for p in partition:
+        entry = p['entry']
+        path = entry['path'][1:]
+        proceed = False
+        for e in EXTS:
+            if path.endswith(e):
+                proceed = True
+                break
+
+        if proceed:
+            url = entry.get('localUrl')
+            if url is None:
+                key_parts = entry['storeKey'].split(':')
+                url = "%s/api/%s/%s/%s" % (base_url, key_parts[0], key_parts[1], path)
+
+            print "Checking: %s" % url
+
+            r = requests.get(url, stream=True)
+            if r.status_code != 200:
+                raise Exception("Failed to download: %s" % url)
+
+            print "Getting size header for: %s" % url
+            header_size=int(r.headers['content-length'])
+
+            print "Preparing temp directory for writing to disk: %s, using temp base: %s and path: %s" % (url, tmp, path)
+            dest = os.path.join(tmp, path)
+            print "Calculating dir of: %s" % dest
+            destdir = os.path.dirname(dest)
+            print "Calculated temp dir as: %s" % destdir
+            if not os.path.isdir(destdir):
+                print "Creating directory: %s" % destdir
+                os.makedirs(destdir)
+
+            print "Writing to disk: %s" % url
+            with open(dest, 'wb') as f:
+                #r.raw.decode_content = True
+                shutil.copyfileobj(r.raw, f)
+
+            print "Checking written size against report record for: %s" % url
+            entry_data = {'path': path, 'local_url': url, 'type':p['dataset']}
+
+            dest_sz = os.path.getsize(dest)
+            if entry['size'] != dest_sz or entry['size'] != header_size or dest_sz != header_size:
+                entry_data['size'] = {'success': False, 'record': entry['size'], 'header': header_size, 'calculated': dest_sz}
+            else:
+                entry_data['size'] = {'success': True}
+
+            print "Calculating checksums for: %s" % url
+            _compare_checksum('md5', url, dest, entry, entry_data)
+            _compare_checksum('sha1', url, dest, entry, entry_data)
+            # compare_checksum('sha256', url, dest, entry, entry_data)
+
+            append=False
+            for k in ['size', 'md5', 'sha1']:
+                if entry_data[k]['success'] is False:
+                    print "FAIL: %s" % url
+                    append = True
+                    break
+
+            if append is True:
+                results.append(entry_data)
+
+    return results
+
+def _compare_checksum(checksum_type, url, dest, entry, entry_data):
+    check_url = url + '.' + checksum_type
+    print "Retrieving %s checksum: %s" % (checksum_type, check_url)
+    
+    r = requests.get(check_url)
+    if r.status_code == 200:
+        check_file = r.text
+    else:
+        check_file = None
+
+    print "Calculating %s checksum from file on disk for: %s" % (checksum_type, url)
+    check = hashlib.new(checksum_type, open(dest, 'rb').read()).hexdigest()
+    if entry[checksum_type] != check: # or entry[checksum_type] != check_file or check != check_file:
+        entry_data[checksum_type] = {'success': False, 'record': entry[checksum_type], 'file': check_file, 'calculated': check}
+    else:
+        entry_data[checksum_type] = {'success': True}
+
+
 class Reporter(Thread):
     def __init__(self, report_queue):
         Thread.__init__(self)
@@ -18,113 +166,11 @@ class Reporter(Thread):
     def run(self):
         while True:
             try:
-                (builddir, report) = self.queue.get()
-
-                report_name = os.path.basename(builddir)
-
-                input_name = os.path.join(builddir, "%s-report.json" % report_name)
-                with open(input_name, 'w') as f:
-                    f.write(json.dumps(report, indent=2))
-
-                downloads = report.get('downloads') or []
-                uploads = report.get('uploads') or []
-
-                tmp = 'content-temp'
-                if os.path.isdir(tmp):
-                    shutil.rmtree(tmp)
-
-                os.makedirs(tmp)
-
-                print "Got %d downloads and %d uploads" % (len(downloads), len(uploads))
-
-                entries = []
-                if uploads is not None:
-                    for e in uploads:
-                        entries.append({'dataset': 'upload', 'entry': e})
-
-                if downloads is not None:
-                    for e in downloads:
-                        entries.append({'dataset': 'download', 'entry': e})
-
-                result = {'results': []}
-                self._process_partition(entries, result['results'])
-
-                output_name = os.path.join(builddir, "%s-verify.json" % report_name)
-                with open(output_name, 'w') as f:
-                    f.write(json.dumps(result, indent=2))
-
-                print "Wrote: %s (%d results)" % (output_name, len(result['results']))
-            except KeyboardInterrupt:
-                print "Keyboard interrupt in process: ", process_number
+                (builddir, url, tracking_id) = self.queue.get()
+                verify_report(builddir, url, tracking_id)
+            except Exception as e:
+                print e
                 break
             finally:
                 self.queue.task_done()
-
-    def _process_partition(self, partition, results):
-        for p in partition:
-            entry = p['entry']
-            path = entry['path'][1:]
-            proceed = False
-            for e in EXTS:
-                if path.endswith(e):
-                    proceed = True
-                    break
-
-            if proceed:
-                url = entry['localUrl']
-                print "Checking: %s" % url
-
-                r = requests.get(url, stream=True)
-                if r.status_code != 200:
-                    raise Exception("Failed to download: %s" % url)
-
-                header_size=int(r.headers['content-length'])
-
-                dest = os.path.join(tmp, path)
-                destdir = os.path.dirname(dest)
-                if not os.path.isdir(destdir):
-                    os.makedirs(destdir)
-
-                with open(dest, 'wb') as f:
-                    #r.raw.decode_content = True
-                    shutil.copyfileobj(r.raw, f)
-
-                entry_data = {'path': path, 'local_url': url, 'type':p['dataset']}
-
-                dest_sz = os.path.getsize(dest)
-                if entry['size'] != dest_sz or entry['size'] != header_size or dest_sz != header_size:
-                    entry_data['size'] = {'success': False, 'record': entry['size'], 'header': header_size, 'calculated': dest_sz}
-                else:
-                    entry_data['size'] = {'success': True}
-
-                self._compare_checksum('md5', url, dest, entry, entry_data)
-                self._compare_checksum('sha1', url, dest, entry, entry_data)
-                # compare_checksum('sha256', url, dest, entry, entry_data)
-
-                append=False
-                for k in ['size', 'md5', 'sha1']:
-                    if entry[k]['success'] is False:
-                        append = True
-                        break
-
-                if append is True:
-                    results.append(entry_data)
-
-        return results
-
-    def _compare_checksum(self, checksum_type, url, dest, entry, entry_data):
-        check_url = url + '.' + checksum_type
-        print "Retrieving checksum: %s" % check_url
-        
-        r = requests.get(check_url)
-        if r.status_code == 200:
-            check_file = r.text
-        else:
-            check_file = None
-
-        check = hashlib.new(checksum_type, open(dest, 'rb').read()).hexdigest()
-        if entry[checksum_type] != check: # or entry[checksum_type] != check_file or check != check_file:
-            entry_data[checksum_type] = {'success': False, 'record': entry[checksum_type], 'file': check_file, 'calculated': check}
-        else:
-            entry_data[checksum_type] = {'success': True}
 

--- a/multibuild/multicheck.py
+++ b/multibuild/multicheck.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import argparse
+import mb
+import mb.reporter
+import requests
+import json
+from Queue import Queue
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('indy_url', help='Indy base url (eg. http://localhost:8080)')
+parser.add_argument('-t', '--threads', type=int, default=4, help='Number of report verifiers')
+
+args = parser.parse_args()
+
+report_queue = Queue()
+
+try:
+    task_ids = mb.reporter.get_sealed_reports(args.indy_url)
+    print "\n".join(task_ids)
+
+    if not os.path.isdir('builds'):
+        os.makedirs('builds')
+
+    for t in range(args.threads):
+        thread = mb.reporter.Reporter(report_queue)
+        thread.daemon = True
+        thread.start()
+
+    for tid in task_ids:
+        builddir = "builds/%s" % tid
+        if not os.path.isdir(builddir):
+            os.makedirs(builddir)
+
+        report_queue.put((builddir, args.indy_url, tid))
+        # mb.reporter.verify_report(builddir, args.indy_url, tid)
+
+    report_queue.join()
+except (KeyboardInterrupt, SystemExit) as e:
+    print e
+    print "Quitting."
+


### PR DESCRIPTION
Added a script that will pull down all the tracking reports from an Indy instance
and verify them all. Other changes support that work, except for the change
to start-indy.sh...in this change, I simply enabled NFS usage again.